### PR TITLE
Improve segment split and add unit test

### DIFF
--- a/split_utils.py
+++ b/split_utils.py
@@ -1,0 +1,66 @@
+import re
+
+# Patterns to detect metadata lines
+_METADATA_PREFIXES = [
+    '--',
+    'http',
+    'Timestamp:',
+    'Map view:',
+    'Source:',
+    '@'
+]
+
+def _is_metadata(line: str) -> bool:
+    line = line.strip()
+    if not line:
+        return False
+    if any(line.startswith(prefix) for prefix in _METADATA_PREFIXES):
+        return True
+    # match two letter comment tags like cc- jj- mm-
+    if re.match(r'^[A-Za-z]{2}-', line):
+        return True
+    return False
+
+def extract_metadata_lines(text: str):
+    """Return a list of metadata lines found in ``text``."""
+    return [ln for ln in text.splitlines() if _is_metadata(ln)]
+
+def split_segment(title: str, content: str, original_text: str, split_points):
+    """Split ``content`` using ``split_points`` and duplicate metadata lines.
+
+    Parameters
+    ----------
+    title : str
+        Title line to prepend to each sub-segment.
+    content : str
+        Content lines without the title.
+    original_text : str
+        Complete original text for metadata extraction.
+    split_points : Iterable[int]
+        Line indexes after which to split.
+
+    Returns
+    -------
+    list[str]
+        A list of new segments including metadata lines.
+    """
+    lines = content.splitlines()
+    split_points = sorted({int(p) for p in split_points})
+    metadata_lines = extract_metadata_lines(original_text)
+    segments = []
+    start = 0
+    for sp in split_points:
+        sp = max(0, min(sp, len(lines) - 1))
+        segment_content = "\n".join(lines[start:sp + 1])
+        seg = title.strip() + "\n" + segment_content
+        for m in metadata_lines:
+            seg += "\n" + m
+        segments.append(seg)
+        start = sp + 1
+    if start < len(lines):
+        final_content = "\n".join(lines[start:])
+        seg = title.strip() + "\n" + final_content
+        for m in metadata_lines:
+            seg += "\n" + m
+        segments.append(seg)
+    return segments

--- a/tests/test_split_utils.py
+++ b/tests/test_split_utils.py
@@ -1,0 +1,24 @@
+import unittest
+import split_utils
+
+class SplitSegmentTests(unittest.TestCase):
+    def test_metadata_copied(self):
+        title = '"Title:news"'
+        content = (
+            'The local government bought a new football field. The president called africa.'
+            '\n\n--tag1.jpg\nmm-tag2\nhttps://www.news.com/article.htmp\n'
+            'cc-comment tag\njj-jtag\nTimestamp: 11:44pm EST\n'
+        )
+        original_text = title + '\n' + content
+        segments = split_utils.split_segment(title, content, original_text, [0])
+        self.assertEqual(len(segments), 2)
+        for seg in segments:
+            self.assertIn('--tag1.jpg', seg)
+            self.assertIn('mm-tag2', seg)
+            self.assertIn('https://www.news.com/article.htmp', seg)
+            self.assertIn('cc-comment tag', seg)
+            self.assertIn('jj-jtag', seg)
+            self.assertIn('Timestamp: 11:44pm EST', seg)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/text_sorter.py
+++ b/text_sorter.py
@@ -1120,73 +1120,11 @@ class TextSorterApp(ctk.CTk):
         if not split_points:
             self.add_to_log(f"Can't split segment - missing split points", "warning")
             return False
-        
-        # Get the original title to use for all sub-segments
-        title_format = original_title.strip()
-        
-        # Split the content into lines to handle paragraph-based splitting
-        lines = content.splitlines()
-        
-        # Sort split points in ascending order
-        split_points.sort()
-        
-        # Extract metadata (timestamps, URLs, images, comments) from the original text
-        metadata_lines = []
-        for line in original_text.splitlines():
-            # Check if line is metadata
-            if (line.startswith('--') or 
-                line.startswith('http') or 
-                line.startswith('Timestamp:') or 
-                line.startswith('Map view:') or 
-                line.startswith('Source:') or 
-                line.startswith('cc-') or 
-                line.startswith('@') or
-                re.match(r'^[A-Za-z]{2}-', line)):
-                metadata_lines.append(line)
-        
-        # Create an array to hold the split segments
-        segments = []
-        
-        # Add sub-segments based on split points
-        start_idx = 0
-        for i, split_point in enumerate(split_points):
-            # Adjust split point to ensure it's within bounds
-            split_point = min(split_point, len(lines) - 1)
-            split_point = max(split_point, 0)
-            
-            # Get content for this sub-segment
-            if split_point >= len(lines):
-                # If split point is beyond the end, just take all remaining lines
-                segment_content = "\n".join(lines[start_idx:])
-            else:
-                # Take lines from start to split point (inclusive)
-                segment_content = "\n".join(lines[start_idx:split_point+1])
-            
-            # Create a new segment with the original title and metadata
-            new_segment = title_format + "\n" + segment_content
-            
-            # Include all metadata for every segment
-            for line in metadata_lines:
-                new_segment += "\n" + line
-            
-            # Add to segments list
-            segments.append(new_segment)
-            
-            # Update start index for next segment
-            start_idx = split_point + 1
-        
-        # Add the final segment (from last split point to end)
-        if start_idx < len(lines):
-            final_content = "\n".join(lines[start_idx:])
-            
-            # Create a new segment with the original title and metadata
-            new_segment = title_format + "\n" + final_content
-            
-            # Include all metadata for this segment too
-            for line in metadata_lines:
-                new_segment += "\n" + line
-            
-            segments.append(new_segment)
+
+        # Use helper from split_utils to create sub-segments with metadata
+        from split_utils import split_segment
+
+        segments = split_segment(original_title, content, original_text, split_points)
         
         # Log what we're doing
         self.add_to_log(f"Splitting segment #{self.current_segment_index + 1} into {len(segments)} sub-segments", "highlight")


### PR DESCRIPTION
## Summary
- factor out tag handling to `split_utils`
- use `split_segment` helper when splitting segments
- add unit test to verify metadata lines are duplicated in split output

## Testing
- `python -m unittest discover -v -s tests`

------
https://chatgpt.com/codex/tasks/task_b_6841970b5c8c832a9dc2b168c02212c7