### PR TITLE
Fix leading newlines in parsed segments

### DIFF
--- a/tests/test_split_utils.py
+++ b/tests/test_split_utils.py
@@ -1,4 +1,9 @@
 import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
 import split_utils
 
 class SplitSegmentTests(unittest.TestCase):

--- a/text_sorter.py
+++ b/text_sorter.py
@@ -520,9 +520,9 @@ class TextSorterApp(ctk.CTk):
             self.segments = []
             for match in matches:
                 title = match.group(1).strip()
-                segment_content = match.group(2)
-                # Get the exact original text for this segment
-                original_text = match.group(0)
+                segment_content = match.group(2).lstrip("\n")
+                # Get the exact original text for this segment (without leading blank lines)
+                original_text = match.group(0).lstrip("\n")
                 # Store the tuple (title, content, original_text)
                 self.segments.append((title, segment_content, original_text))
             


### PR DESCRIPTION
## Summary
- remove leading newlines when parsing segments in `text_sorter.py`
- make tests import `split_utils` reliably

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6841c12b4920832a9ae6044afed73fa4