### PR TITLE
Fix metadata loss when splitting segments

### DIFF
--- a/text_sorter.py
+++ b/text_sorter.py
@@ -514,7 +514,11 @@ class TextSorterApp(ctk.CTk):
             segment_pattern = r'((?:^|\n)\s*"Title:[^"]+")(.+?)(?=(?:^|\n)\s*"Title:|$)'
             
             # Find positions of each segment to preserve exact text
-            matches = list(re.finditer(segment_pattern, content, re.DOTALL | re.MULTILINE))
+            # Use DOTALL so the pattern spans newlines but avoid MULTILINE
+            # to ensure $ only matches end-of-string. MULTILINE caused
+            # segments to stop after the first line when a blank line was
+            # present, dropping metadata such as timestamps and tags.
+            matches = list(re.finditer(segment_pattern, content, re.DOTALL))
             
             # Extract segments with their exact original text
             self.segments = []


### PR DESCRIPTION
## Summary
- fix regex so segments capture all lines including metadata tags
- ensure tests still pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841c7be1850832abab83db4673bde3d